### PR TITLE
Mark $imageId as mixed to prevent typing errors. Closes #57.

### DIFF
--- a/src/models/Recipe.php
+++ b/src/models/Recipe.php
@@ -128,9 +128,9 @@ class Recipe extends Model
     public array $equipment = [];
 
     /**
-     * @var ?array
+     * @var mixed
      */
-    public ?array $imageId = null;
+    public mixed $imageId = null;
 
     /**
      * @var ?array


### PR DESCRIPTION
A typing error was triggered because some image queries can be arrays and others are straight up image ids (strings), so changing the type to mixed solves this issue.