### PR TITLE
Fix array access on new type Int

### DIFF
--- a/src/models/Recipe.php
+++ b/src/models/Recipe.php
@@ -457,7 +457,7 @@ class Recipe extends Model
     {
         $result = '';
         if ($this->imageId) {
-            $image = Craft::$app->getAssets()->getAssetById($this->imageId[0]);
+            $image = Craft::$app->getAssets()->getAssetById($this->imageId);
             if ($image) {
                 $result = $image->getUrl($transform);
             }
@@ -473,7 +473,7 @@ class Recipe extends Model
     {
         $result = '';
         if ($this->videoId) {
-            $video = Craft::$app->getAssets()->getAssetById($this->videoId[0]);
+            $video = Craft::$app->getAssets()->getAssetById($this->videoId);
             if ($video) {
                 $result = $video->getUrl();
             }

--- a/src/models/Recipe.php
+++ b/src/models/Recipe.php
@@ -489,7 +489,7 @@ class Recipe extends Model
     {
         $result = '';
         if ($this->videoId) {
-            $video = Craft::$app->getAssets()->getAssetById($this->videoId[0]);
+            $video = Craft::$app->getAssets()->getAssetById($this->videoId);
             if ($video) {
                 $result = $video->dateCreated->format('c');
             }


### PR DESCRIPTION
This is simply a follow-up on our last exchange! This one slipped my attention, but there were some array access on imageId and videoId still in the Recipe model.

If I understand right, the array accesses still found around line 162 in fields/Recipe.php should stay since it comes from the admin input and the input accepts arrays regardless of the limit of 1... I think. 🤔  https://github.com/nystudio107/craft-recipe/blob/develop-v4/src/fields/Recipe.php#L162 