### PR TITLE
Fixes nutritional information requests when in a block field type

### DIFF
--- a/src/assetbundles/recipefield/dist/js/Recipe.js
+++ b/src/assetbundles/recipefield/dist/js/Recipe.js
@@ -60,7 +60,7 @@
                     var ingredients = [];
 
                     var field = $(this).attr('data-field');
-                    $('#fields-' + field + 'ingredients tbody tr').each(function() {
+                    $('#' + field + 'ingredients tbody tr').each(function() {
                         var ingredient = [];
                         $(this).find('textarea, select').each(function() {
                             ingredient.push($(this).val());

--- a/src/templates/_components/fields/Recipe_input.twig
+++ b/src/templates/_components/fields/Recipe_input.twig
@@ -344,7 +344,7 @@
             {% if hasApiCredentials %}
                 <div class="fetch-nutritional-info text-right" style="margin: -8px 0 -24px;">
                     <span class="spinner hidden"></span>
-                    <button data-field="{{ name }}" class="btn submit">
+                    <button data-field="{{ nameSpacedId }}" class="btn submit">
                         Fetch Nutritional Information
                     </button>
                 </div>


### PR DESCRIPTION
This PR fixes https://github.com/nystudio107/craft-recipe/issues/63 requests to fetch nutritional information when the field is in a block field type (such as Matrix), by replacing the field `name` with its `nameSpacedId`.