### PR TITLE
Fixes compatibility with FeedMe's base FieldInterface

### DIFF
--- a/src/integrations/RecipeFeedMeField.php
+++ b/src/integrations/RecipeFeedMeField.php
@@ -35,7 +35,7 @@ class RecipeFeedMeField extends Field implements FieldInterface
     // Templates
     // =========================================================================
 
-    public function getMappingTemplate()
+    public function getMappingTemplate(): string
     {
         return 'recipe/_integrations/feed-me';
     }
@@ -44,7 +44,7 @@ class RecipeFeedMeField extends Field implements FieldInterface
     // Public Methods
     // =========================================================================
 
-    public function parseField()
+    public function parseField(): mixed
     {
         $preppedData = [];
 


### PR DESCRIPTION
Resolves a 500 error in the FeedMe mapping page when Recipe plugin is enabled, by adding return type declarations to getMappingTemplate and parseField methods to bring it back in line with FeedMe's base FieldInterface. This issue was occurring even if a recipe field was not in the field layout. With the correct base branch this time!